### PR TITLE
Expose all of CommonCrypto, not just CommonDigest

### DIFF
--- a/ios-commoncrypto.podspec.json
+++ b/ios-commoncrypto.podspec.json
@@ -1,15 +1,16 @@
 {
-  "name": "libCommonCrypto",
-  "version": "0.1.1",
+  "name": "ios-commoncrypto",
+  "version": "0.1.2",
   "license": "MIT",
-  "summary": "CommonCrypto module maps for swift",
-  "homepage": "https://github.com/mogstad/CommonCrypto",
+  "summary": "CommonCrypto module maps for Swift",
+  "homepage": "https://github.com/cjwirth/ios-commoncrypto",
   "authors": {
-    "Bjarne Mogstad": "me@mogstad.co"
+    "Bjarne Mogstad": "me@mogstad.co",
+    "Caesar Wirth": "caesar@cjwirth.com"
   },
   "source": {
-    "git": "https://github.com/mogstad/CommonCrypto.git",
-    "tag": "v0.1.1"
+    "git": "https://github.com/cjwirth/ios-commoncrypto.git",
+    "tag": "0.1.2"
   },
   "module_name": "CommonCrypto",
   "platforms": {

--- a/modules/ios/module.modulemap
+++ b/modules/ios/module.modulemap
@@ -1,11 +1,5 @@
-framework module CommonCrypto {
-  umbrella header "CommonCrypto.h"
-
-  module CommonDigest [system] {
-    header "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk/usr/include/CommonCrypto/CommonDigest.h"
+framework module CommonCrypto [system] {
+    umbrella header "CommonCrypto.h"
+    header "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk/usr/include/CommonCrypto/CommonCrypto.h"
     export *
-  }
-
-  export *
-  module * { export * }
 }

--- a/modules/macos/module.modulemap
+++ b/modules/macos/module.modulemap
@@ -1,11 +1,5 @@
-framework module CommonCrypto {
-  umbrella header "CommonCrypto.h"
-
-  module CommonDigest [system] {
-    header "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/CommonCrypto/CommonDigest.h"
+framework module CommonCrypto [system] {
+    umbrella header "CommonCrypto.h"
+	header "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/CommonCrypto/CommonCrypto.h"
     export *
-  }
-
-  export *
-  module * { export * }
 }

--- a/modules/tvos/module.modulemap
+++ b/modules/tvos/module.modulemap
@@ -1,11 +1,5 @@
-framework module CommonCrypto {
-  umbrella header "CommonCrypto.h"
-
-  module CommonDigest [system] {
-    header "/Applications/Xcode.app/Contents/Developer/Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS.sdk/usr/include/CommonCrypto/CommonDigest.h"
+framework module CommonCrypto [system] {
+    umbrella header "CommonCrypto.h"
+	header "/Applications/Xcode.app/Contents/Developer/Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS.sdk/usr/include/CommonCrypto/CommonCrypto.h"
     export *
-  }
-
-  export *
-  module * { export * }
 }

--- a/modules/watchos/module.modulemap
+++ b/modules/watchos/module.modulemap
@@ -1,11 +1,5 @@
-framework module CommonCrypto {
-  umbrella header "CommonCrypto.h"
-
-  module CommonDigest [system] {
-    header "/Applications/Xcode.app/Contents/Developer/Platforms/WatchOS.platform/Developer/SDKs/WatchOS.sdk/usr/include/CommonCrypto/CommonDigest.h"
+framework module CommonCrypto [system] {
+    umbrella header "CommonCrypto.h"
+	header "/Applications/Xcode.app/Contents/Developer/Platforms/WatchOS.platform/Developer/SDKs/WatchOS.sdk/usr/include/CommonCrypto/CommonCrypto.h"
     export *
-  }
-
-  export *
-  module * { export * }
 }


### PR DESCRIPTION
This just makes it so the entirety of CommonCrypto is accessible when using this pod, and not just CommonDigest.

You don't actually have to take the version bump and podspec (I'd rather you wouldn't, because I don't want to keep my fork forever).